### PR TITLE
fix requirements tab crashing workspace view

### DIFF
--- a/frontend/src/components/UI/Cards/RequirementsTabCard.vue
+++ b/frontend/src/components/UI/Cards/RequirementsTabCard.vue
@@ -134,7 +134,6 @@ export default {
 		const textValue = ref("https://github.com/ditrit/leto.git");
 		return {
 			isOpened,
-			Test,
 			title1,
 			title2,
 			title3,


### PR DESCRIPTION
Undeclared variable caused entire view to break when entering requirements tab